### PR TITLE
Atualizar party ID da 3D para 2026

### DIFF
--- a/src/app/api/v1/3d/scores/route.ts
+++ b/src/app/api/v1/3d/scores/route.ts
@@ -6,10 +6,10 @@ import { AAACECRole } from "../../../../domain/aaacec_roles";
 import { DDDRepository } from "../../../../repositories/ddd_repository";
 import { AddScores3DDTO, ScoresBetween3DDTO } from "./scores.dto";
 
-const PARTY_ID = "3d";
+const PARTY_ID = "3d2026";
 
 class Scores3DController {
-  /** Aplica deltas no evento "3d". */
+  /** Aplica deltas no evento "3d2026". */
   @Authorize([AAACECRole.ADMIN, AAACECRole.WORKER])
   static async POST(req: Request) {
     try {


### PR DESCRIPTION
## Summary
- troca o identificador interno da festa 3D de `3d` para `3d2026`
- mantém as rotas públicas existentes e isola os registros do evento 2026 no Firestore

## Test plan
- [x] `npm run lint` (concluído com avisos preexistentes)
- [x] `npm run build` (concluído com avisos preexistentes)
- [x] revisar o diff para confirmar que somente o party ID e seu comentário mudaram
